### PR TITLE
silently try to resend a HTTP request ONLY WHEN the server closed the connection without returning any data at all

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -371,7 +371,8 @@ sub request {
         my $n = $self->read_timeout($sock,
             \$buf, $self->{bufsize}, length($buf), $timeout_at);
         if(!$n) { # error or eof
-            if($in_keepalive && (defined($n) || $!==ECONNRESET)) {
+            if ($in_keepalive && length($buf) == 0
+                && (defined($n) || $!==ECONNRESET)) {
                 # the server closes the connection (maybe because of keep-alive timeout)
                 return $self->request(%args);
             }


### PR DESCRIPTION
Furl should not resend the HTTP request if the server returned some part of a HTTP response and then closed the connection (since it is clearly not a disconnection due to a keep-alive timeout)
