### PR TITLE
Fixed wrong dereference and add its test.

### DIFF
--- a/lib/Furl.pm
+++ b/lib/Furl.pm
@@ -26,7 +26,7 @@ sub new {
 }
 
 sub agent {
-    @_ == 2 ? $$_[0]->agent($_[1]) : $$_[0]->agent;
+    @_ == 2 ? ${$_[0]}->agent($_[1]) : ${$_[0]}->agent;
 }
 
 sub env_proxy {

--- a/t/300_high/02_agent.t
+++ b/t/300_high/02_agent.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Furl;
+
+subtest 'agent' => sub {
+    my $furl = Furl->new( agent => 'Furl/test' );
+    is $furl->agent, "Furl/test", 'get User-Agent';
+
+    $furl->agent('Furl/new');
+    is $furl->agent, "Furl/new", 'set new User-Agent';
+};
+
+done_testing;


### PR DESCRIPTION
Furl->agent does not work well, because its dereference is wrong.

Output t/300_high/02_agent.t with original code

```
t/300_high/02_agent.t .. Can't call method "agent" on an undefined value
at /home/syohei/program/perl/Furl/blib/lib/Furl.pm line 29.
```

`$$_[0]` means `${$_}[0]`, not `${$_[0]}`.
