### PR TITLE
SSL_verifycn_scheme is not required if skipping verification

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -568,10 +568,12 @@ sub connect :method {
 sub _ssl_opts {
     my $self = shift;
     my $ssl_opts = $self->{ssl_opts};
-    unless (exists $ssl_opts->{SSL_verify_mode} && exists $ssl_opts->{SSL_verifycn_scheme}) {
+    unless (exists $ssl_opts->{SSL_verify_mode}) {
         # set SSL_VERIFY_PEER as default.
         $ssl_opts->{SSL_verify_mode}     = IO::Socket::SSL::SSL_VERIFY_PEER();
-        $ssl_opts->{SSL_verifycn_scheme} = 'www'
+        unless (exists $ssl_opts->{SSL_verifycn_scheme}) {
+            $ssl_opts->{SSL_verifycn_scheme} = 'www'
+        }
     }
     if ($ssl_opts->{SSL_verify_mode}) {
         unless (exists $ssl_opts->{SSL_ca_file} || exists $ssl_opts->{SSL_ca_path}) {


### PR DESCRIPTION
Furl->new(ssl_opts=>{SSL_verify_mode=>0}) becomes error,  need adding SSL_verifycn_scheme if  I want to skip verification
