### PR TITLE
fix test. force response HTTP/1.0

### DIFF
--- a/t/100_low/22_keep_alive_http10.t
+++ b/t/100_low/22_keep_alive_http10.t
@@ -49,6 +49,7 @@ test_tcp(
             max_keepalive_reqs => 10,
         )->run(sub {
             my $env = shift;
+            $env->{SERVER_PROTOCOL} = 'HTTP/1.0'; #force response HTTP/1.0
             return [ 200,
                 [ 'Content-Length' => length($env->{REQUEST_URI}) ],
                 [$env->{REQUEST_URI}]


### PR DESCRIPTION
t/100_low/22_keep_alive_http10.t failes with Starlet >= 0.20 that supports HTTP/1.1
need downgrading protocol to HTTP/1.0.
