### PR TITLE
Trace the Furl's request/response if `$Furl::TRACE_FILE` is true.

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Tokuhiro Matsuno <tokuhirom@gmail.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v0.11.0, CPAN::Meta::Converter version 2.133380",
+   "generated_by" : "Minilla/v0.12.0, CPAN::Meta::Converter version 2.133380",
    "license" : [
       "perl_5"
    ],

--- a/README.md
+++ b/README.md
@@ -142,6 +142,28 @@ This is an easy-to-use alias to `request()`, sending the `DELETE` method.
 
 Loads proxy settings from `$ENV{HTTP_PROXY}` and `$ENV{NO_PROXY}`.
 
+# PACKAGE VARIABLES
+
+- `$Furl::TRACE_FILE`
+
+    __(EXPERIMENTAL)__
+
+    If you set file name to this variable, Furl write the resquest and response to this file.
+
+    It makes easy to debug the request result.
+
+    (The log format may change without notice.)
+
+    You can set this variable by `FURL_TRACE_FILE` environment variable.
+
+# ENVIRONMENT VARIABLES
+
+- FURL\_TRACE\_FILE
+
+    __(EXPERIMENTAL)__
+
+    This environment variable will set to `$Furl::TRACE_FILE` when loaded this module.
+
 # FAQ
 
 - Does Furl depends on XS modules?
@@ -224,6 +246,7 @@ Loads proxy settings from `$ENV{HTTP_PROXY}` and `$ENV{NO_PROXY}`.
                 if $received_size >= $next_update;
             }
         );
+
 - HTTPS requests claims warnings!
 
     When you make https requests, IO::Socket::SSL may complain about it like:

--- a/t/300_high/07_trace_file.t
+++ b/t/300_high/07_trace_file.t
@@ -1,0 +1,82 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use t::Util;
+use Furl;
+use Test::TCP;
+use Test::Requires qw(Plack::Request Test::MockTime HTTP::Body Plack::Loader), 'Plack';
+
+Test::MockTime::set_absolute_time('2014-03-15T01:02:31Z');
+
+test_tcp(
+    client => sub {
+        my $port = shift;
+
+        local $Furl::TRACE_FILE = File::Temp->new();
+        my $furl = Furl->new();
+        my $url = "http://127.0.0.1:$port";
+
+        {
+            my $res = $furl->post("http://127.0.0.1:$port", ['X-Foo' => 'Bar'], ['A' => 'B']);
+            is $res->status, 200;
+
+            my $src = slurp($Furl::TRACE_FILE);
+            like $src, qr/X-Foo: Bar/; # request header
+            like $src, qr/A=B/; # request content
+            like $src, qr/OK!!!/; # response content
+        }
+
+        {
+            my $res = $furl->get("http://127.0.0.1:$port", ['X-Moe' => 'foo']);
+            is $res->status, 200;
+
+            my $src = slurp($Furl::TRACE_FILE);
+            like $src, qr/X-Moe: foo/; # request header
+            like $src, qr/OK!!!/; # response content
+
+            note $src;
+        }
+
+        done_testing;
+    },
+    server => sub {
+        my $port = shift;
+        Plack::Loader->auto( port => $port )->run(sub {
+            my $env     = shift;
+            return [
+                200,
+                [ 'Content-Length' => 5 ],
+                ['OK!!!']
+            ];
+        });
+    }
+);
+
+sub slurp {
+    my $fname = shift;
+    open my $fh, '<', $fname
+        or Carp::croak("Can't open '$fname' for reading: '$!'");
+    scalar(do { local $/; <$fh> })
+}
+
+__END__
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+POST / HTTP/1.1
+Connection: keep-alive
+User-Agent: Furl::HTTP/<<VERSION>>
+X-Foo: Bar
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 3
+Host: 127.0.0.1:<<PORT>>
+
+
+A=B
+================================================================================
+200 OK
+content-length: 2
+date: Sat, 15 Mar 2014 01:02:31 GMT
+server: HTTP::Server::PSGI
+
+OK
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<


### PR DESCRIPTION
Also, FURL_TRACE_FILE environment variable is supported.
