### PR TITLE
remove trailing whitespace from Authorization header

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -276,7 +276,7 @@ sub request {
             if (defined $proxy_user) {
                 _requires('MIME/Base64.pm',
                     'Basic auth');
-                $proxy_authorization = 'Basic ' . MIME::Base64::encode_base64("$proxy_user:$proxy_pass");
+                $proxy_authorization = 'Basic ' . MIME::Base64::encode_base64("$proxy_user:$proxy_pass","");
             }
             if ($scheme eq 'http') {
                 ($sock, $err_reason)
@@ -327,7 +327,7 @@ sub request {
         }
         if (defined $username) {
             _requires('MIME/Base64.pm', 'Basic auth');
-            push @headers, 'Authorization', 'Basic ' . MIME::Base64::encode_base64("${username}:${password}");
+            push @headers, 'Authorization', 'Basic ' . MIME::Base64::encode_base64("${username}:${password}","");
         }
 
         my $content       = $args{content};

--- a/t/100_low/32_proxy_auth.t
+++ b/t/100_low/32_proxy_auth.t
@@ -65,14 +65,12 @@ test_tcp(
     server => sub { # proxy server
         my $proxy_port = shift;
         my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
-        my $token = "Basic " . encode_base64( "dankogai:kogaidan" );
+        my $token = "Basic " . encode_base64( "dankogai:kogaidan", "" );
         $proxy->push_filter(
             request => HTTP::Proxy::HeaderFilter::simple->new(
                 sub {
                     my ( $self, $headers, $request ) = @_;
                     my $auth = $self->proxy->hop_headers->header('Proxy-Authorization') || '';
-                    $auth =~ s/\s*$//;
-                    $token =~ s/\s*$//;
 
                     # check the credentials
                     if ( $auth ne $token ) {

--- a/t/100_low/33_basic_auth.t
+++ b/t/100_low/33_basic_auth.t
@@ -28,7 +28,7 @@ test_tcp(
         my $port = shift;
         t::HTTPServer->new(port => $port)->run(sub {;
             my $env = shift;
-            is($env->{HTTP_AUTHORIZATION}, 'Basic ZGFua29nYWk6a29nYWlkYW4= ');
+            is($env->{HTTP_AUTHORIZATION}, 'Basic ZGFua29nYWk6a29nYWlkYW4=');
             return [ 200,
                 [ 'Content-Length' => length($env->{REQUEST_URI}) ],
                 [$env->{REQUEST_URI}]


### PR DESCRIPTION
It's required removing trailing whitespace from Authorization header.

here is strace log of access denied.

```
write(3, "GET / HTTP/1.1\r\nConnection: keep-alive\r\nUser-Agent: user-agent\r\nAuthorization: Basic xxxxxxxxx \r\nHost: x.x.x.x:xxxx\r\n\r\n", 131) = 131
read(3, 0x28ea640, 10240)               = -1 EAGAIN (Resource temporarily unavailable)
select(8, [3], NULL, [3], {9, 998535})  = 1 (in [3], left {9, 998407})
read(3, "HTTP/1.1 401 OK\nWWW-Authenticate: Basic realm=\"XXXXXXXXX\"\nConnection: close\nContent-type: text/html\n\nPlease enter a valid password!\n", 10240) = 131
```
