### PR TITLE
content-lenght path

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -467,6 +467,11 @@ sub request {
         }
     }
 
+    ### EXTREMELY DUMMY PATH ###
+    $special_headers->{'content-length'} = undef
+        unless $special_headers->{'content-length'} =~ /^\d+$/;
+    ### EXTREMELY DUMMY PATH ###
+
     my $max_redirects = 0;
     my $do_redirect = undef;
     if ($special_headers->{location}) {


### PR DESCRIPTION
Just dummy path to allow to see content when you have got content-lengh like: \d+,\d+
