### PR TITLE
Check only status code when connect SSL over proxy

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -681,7 +681,7 @@ sub connect_ssl_over_proxy {
         return (undef, "Cannot read proxy response: " . _strerror_or_timeout());
     } elsif ( $read == 0 ) {    # eof
         return (undef, "Unexpected EOF while reading proxy response");
-    } elsif ( $buf !~ /^HTTP\/1.[01] 200 Connection established\015\012/ ) {
+    } elsif ( $buf !~ /^HTTP\/1.[01] 200 .+\015\012/ ) {
         return (undef, "Invalid HTTP Response via proxy");
     }
 


### PR DESCRIPTION
Because cannot connect via the proxy which responses `HTTP 1.0 200 OK`.
