### PR TITLE
Update HTTP.pm

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -523,7 +523,7 @@ sub request {
     }
 
     # manage connection cache (i.e. keep-alive)
-    if ($connection_header eq 'keep-alive') {
+    if (lc($connection_header) eq 'keep-alive') {
         my $connection = lc $special_headers->{'connection'};
         if (($res_minor_version == 0
              ? $connection eq 'keep-alive' # HTTP/1.0 needs explicit keep-alive


### PR DESCRIPTION
fix for keep-alive as zmmail proposed.
"In line 526 of Furl/HTTP.pm, FURL checks the HTTP response headers it gets from the server. It will read the Connection from the response header there, and compare the header value with the string keep-alive. The problem is that this does not take into account a different case of the response header. Some HTTP server returns a header value of Keep-Alive (mind the caps), so FURL does not recognize it properly.

I think the following change to Furl/HTTP.pm is more robust.

if ($connection_header eq 'keep-alive') {
if (lc($connection_header) eq 'keep-alive') {"