### PR TITLE
The default port should be omitted from a request line with a proxy?

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -364,9 +364,10 @@ sub request {
         }
 
         # finally, set Host header
-        push @headers, 'Host' => (($port == $default_port) ? $host : "$host:$port");
+        my $request_target = ($port == $default_port) ? $host : "$host:$port";
+        push @headers, 'Host' => $request_target;
 
-        my $request_uri = $proxy ? "$scheme://$host:$port$path_query" : $path_query;
+        my $request_uri = $proxy ? "$scheme://$request_target$path_query" : $path_query;
 
         my $p = "$method $request_uri HTTP/1.1\015\012";
         for (my $i = 0; $i < @headers; $i += 2) {

--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -367,7 +367,7 @@ sub request {
         my $request_target = ($port == $default_port) ? $host : "$host:$port";
         push @headers, 'Host' => $request_target;
 
-        my $request_uri = $proxy ? "$scheme://$request_target$path_query" : $path_query;
+        my $request_uri = $proxy && $scheme eq 'http' ? "$scheme://$request_target$path_query" : $path_query;
 
         my $p = "$method $request_uri HTTP/1.1\015\012";
         for (my $i = 0; $i < @headers; $i += 2) {

--- a/t/100_low/08_proxy.t
+++ b/t/100_low/08_proxy.t
@@ -8,7 +8,7 @@ use Test::More;
 use Plack::Request;
 use Test::Requires qw(Plack::Request HTTP::Body), 'HTTP::Proxy';
 
-plan tests => 7*3;
+plan tests => 9*3*2;
 
 my $verbose = 1;
 {
@@ -20,50 +20,125 @@ my $verbose = 1;
     }
 }
 
+{
+    package Test::UserAgent;
+    use parent qw(LWP::UserAgent);
+    use Test::More;
+
+    sub real_httpd_port {
+        my ($self, $port) = @_;
+        $self->{httpd_port} = $port if defined $port;
+        return $self->{httpd_port};
+    }
+
+    sub simple_request {
+        my ($self, $req, @args) = @_;
+        my $uri = $req->uri;
+        my $host = $req->header('Host');
+
+        if ($self->real_httpd_port) {
+            # test for URL with a default port
+            like $uri.q(), qr!^http://[^:]+/!,
+                'No port number in the request line';
+            unlike $host, qr!:!,
+                'No port number in Host header';
+
+            # replace the port number to correctly connect to the test server
+            $uri->port($self->real_httpd_port);
+        } else {
+            # test for URL with non-default port
+
+            like $uri.q(), qr!^http://[^/]+:[0-9]+/!,
+                'A port number in the request line';
+            like $host, qr/:[0-9]+$/,
+                'A port number in Host header';
+        }
+
+        return $self->SUPER::simple_request($req, @args);
+    }
+}
+
 my $via = "VIA!VIA!VIA!";
 
+my $httpd = Test::TCP->new(code => sub {
+    my $httpd_port = shift;
+    Plack::Loader->auto(port => $httpd_port)->run(sub {
+        my $env = shift;
+
+        my $req = Plack::Request->new($env);
+        is $req->header('X-Foo'), "ppp" if $env->{REQUEST_URI} eq '/foo';
+        like $req->header('User-Agent'), qr/\A Furl::HTTP /xms;
+        my $content = "Hello, foo";
+        return [ 200,
+                 [ 'Content-Length' => length($content) ],
+                 [ $content ]
+             ];
+    });
+});
+
+sub client (%) {
+    my (%url) = @_;
+    for (1..3) { # run some times for testing keep-alive.
+        my $furl = Furl::HTTP->new(proxy => $url{proxy});
+        my ( undef, $code, $msg, $headers, $content ) =
+            $furl->request(
+                url     => $url{request},
+                headers => [ "X-Foo" => "ppp" ]
+            );
+        is $code, 200, "request()";
+        is $msg, "OK";
+        is Furl::HTTP::_header_get($headers, 'Content-Length'), 10;
+        is Furl::HTTP::_header_get($headers, 'Via'), "1.0 $via";
+        is $content, 'Hello, foo'
+            or do{ require Devel::Peek; Devel::Peek::Dump($content) };
+    }
+}
+
+sub test_agent () {
+    return Test::UserAgent->new(
+        env_proxy  => 1,
+        keep_alive => 2,
+        parse_head => 0,
+    );
+}
+
 local $ENV{'HTTP_PROXY'} = '';
+
+# Request target with non-default port
+
 test_tcp(
     client => sub {
         my $proxy_port = shift;
-        test_tcp(
-            client => sub { # http client
-                my $httpd_port = shift;
-                for (1..3) { # run some times for testing keep-alive.
-                    my $furl = Furl::HTTP->new(proxy => "http://127.0.0.1:$proxy_port");
-                    my ( undef, $code, $msg, $headers, $content ) =
-                        $furl->request(
-                            url     => "http://127.0.0.1:$httpd_port/foo",
-                            headers => [ "X-Foo" => "ppp" ]
-                        );
-                    is $code, 200, "request()";
-                    is $msg, "OK";
-                    is Furl::HTTP::_header_get($headers, 'Content-Length'), 10;
-                    is Furl::HTTP::_header_get($headers, 'Via'), "1.0 $via";
-                    is $content, 'Hello, foo'
-                        or do{ require Devel::Peek; Devel::Peek::Dump($content) };
-                }
-            },
-            server => sub { # http server
-                my $httpd_port = shift;
-                Plack::Loader->auto(port => $httpd_port)->run(sub {
-                    my $env = shift;
-
-                    my $req = Plack::Request->new($env);
-                    is $req->header('X-Foo'), "ppp" if $env->{REQUEST_URI} eq '/foo';
-                    like $req->header('User-Agent'), qr/\A Furl::HTTP /xms;
-                    my $content = "Hello, foo";
-                    return [ 200,
-                        [ 'Content-Length' => length($content) ],
-                        [ $content ]
-                    ];
-                });
-            },
+        my $httpd_port = $httpd->port;
+        client(
+            proxy   => "http://127.0.0.1:$proxy_port",
+            request => "http://127.0.0.1:$httpd_port/foo",
         );
     },
     server => sub { # proxy server
         my $proxy_port = shift;
         my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
+        $proxy->agent(test_agent);
+        $proxy->start();
+    },
+);
+
+# Request target with default port
+
+test_tcp(
+    client => sub {
+        my $proxy_port = shift;
+        my $httpd_port = $httpd->port;
+        client(
+            proxy   => "http://127.0.0.1:$proxy_port",
+            request => "http://127.0.0.1/foo", # default port
+        );
+    },
+    server => sub { # proxy server
+        my $proxy_port = shift;
+        my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
+        $proxy->agent(test_agent);
+        $proxy->agent->real_httpd_port($httpd->port);
         $proxy->start();
     },
 );

--- a/t/100_low/08_proxy.t
+++ b/t/100_low/08_proxy.t
@@ -8,7 +8,7 @@ use Test::More;
 use Plack::Request;
 use Test::Requires qw(Plack::Request HTTP::Body), 'HTTP::Proxy';
 
-plan tests => 9*3*2;
+plan tests => (10*2 + 8)*3;
 
 my $verbose = 1;
 {
@@ -66,7 +66,8 @@ my $httpd = Test::TCP->new(code => sub {
         my $env = shift;
 
         my $req = Plack::Request->new($env);
-        is $req->header('X-Foo'), "ppp" if $env->{REQUEST_URI} eq '/foo';
+        is $req->path, '/foo';
+        is $req->header('X-Foo'), "ppp";
         like $req->header('User-Agent'), qr/\A Furl::HTTP /xms;
         my $content = "Hello, foo";
         return [ 200,
@@ -77,18 +78,18 @@ my $httpd = Test::TCP->new(code => sub {
 });
 
 sub client (%) {
-    my (%url) = @_;
+    my (%args) = @_;
     for (1..3) { # run some times for testing keep-alive.
-        my $furl = Furl::HTTP->new(proxy => $url{proxy});
+        my $furl = Furl::HTTP->new(proxy => $args{proxy});
         my ( undef, $code, $msg, $headers, $content ) =
             $furl->request(
-                url     => $url{request},
+                url     => $args{request},
                 headers => [ "X-Foo" => "ppp" ]
             );
         is $code, 200, "request()";
         is $msg, "OK";
         is Furl::HTTP::_header_get($headers, 'Content-Length'), 10;
-        is Furl::HTTP::_header_get($headers, 'Via'), "1.0 $via";
+        is Furl::HTTP::_header_get($headers, 'Via'), $args{via};
         is $content, 'Hello, foo'
             or do{ require Devel::Peek; Devel::Peek::Dump($content) };
     }
@@ -113,6 +114,7 @@ test_tcp(
         client(
             proxy   => "http://127.0.0.1:$proxy_port",
             request => "http://127.0.0.1:$httpd_port/foo",
+            via     => '1.0 VIA!VIA!VIA!',
         );
     },
     server => sub { # proxy server
@@ -132,6 +134,7 @@ test_tcp(
         client(
             proxy   => "http://127.0.0.1:$proxy_port",
             request => "http://127.0.0.1/foo", # default port
+            via     => '1.0 VIA!VIA!VIA!',
         );
     },
     server => sub { # proxy server
@@ -139,6 +142,47 @@ test_tcp(
         my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
         $proxy->agent(test_agent);
         $proxy->agent->real_httpd_port($httpd->port);
+        $proxy->start();
+    },
+);
+
+# SSL over proxy
+
+test_tcp(
+    client => sub {
+        # emulate CONNECT for SSL proxying without a real SSL connection
+        no warnings 'redefine';
+        local *Furl::HTTP::connect_ssl_over_proxy = sub {
+            my ($self, $proxy_host, $proxy_port, $host, $port, $timeout_at, $proxy_authorization) = @_;
+            my $sock = $self->connect($proxy_host, $proxy_port, $timeout_at);
+            my $p = "CONNECT $host:$port HTTP/1.0\015\012Server: $host\015\012";
+            $p .= "\015\012";
+            $self->write_all($sock, $p, $timeout_at) or fail;
+
+            # read the entire response of CONNECT method
+            my $buf = '';
+            while ($buf !~ qr!(?:\015\012){2}!) {
+                my $read = $self->read_timeout(
+                    $sock, \$buf, $self->{bufsize}, length($buf), $timeout_at
+                );
+                defined $read or fail;
+                $read != 0 or fail;
+            }
+
+            $sock;
+        };
+
+        my $proxy_port = shift;
+        my $httpd_port = $httpd->port;
+        client(
+            proxy   => "http://127.0.0.1:$proxy_port",
+            request => "https://127.0.0.1:$httpd_port/foo",
+            # no via since the request goes directly to the origin server
+        );
+    },
+    server => sub { # proxy server
+        my $proxy_port = shift;
+        my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
         $proxy->start();
     },
 );


### PR DESCRIPTION
[`Furl::HTTP` always puts a port number on a request line when a proxy is used](https://github.com/tokuhirom/Furl/blob/430241c4814da27631585d373dc699daadfd0127/lib/Furl/HTTP.pm#L369). I suggest to omit the port number if it is the same as the default `80` or `443`.

I'm using Apache Traffic Server (ATS) as a forward proxy and getting some odd responses from some websites as the following.

1. ATS replaces `Host` header with the request target in the request line (including the port number)
2. Some website (e.g. http://blog.livedoor.jp/ld_pr/) responds differently when the `Host` header includes a port number
    - http://blog.livedoor.jp/ld_pr/ returns 200 without a port number in the `Host` header
        ```
        GET /ld_pr/ HTTP/1.1
        Host: blog.livedoor.jp

        HTTP/1.1 200 OK
        ....
        ````

    - http://blog.livedoor.jp/ld_pr/ returns 404 with a port number in the `Host` header
        ```
        GET /ld_pr/ HTTP/1.1
        Host: blog.livedoor.jp:80

        HTTP/1.1 404 Not Found
        ....
        ````

I think ATS does nothing wrong since RFC 7230 says to do so. This is why I'm not filing a bug report to ATS.

> When a proxy receives a request with an absolute-form of request-target, the proxy MUST ignore the received Host header field (if any) and instead replace it with the host information of the request-target.
> http://tools.ietf.org/html/rfc7230#section-5.4

The one who to blame is the website responding strangely but we should take care of such a broken server.  If there is no other problem, I suggest to omit the default port number as this pull request.
