### PR TITLE
Host name should be passed to SSL connection over proxy

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -699,8 +699,7 @@ sub connect_ssl_over_proxy {
         PeerPort => $port,
         Timeout  => $timeout,
         %$ssl_opts
-    ) or return (
-          undef, "Cannot start SSL connection: " . _strerror_or_timeout());
+    ) or return (undef, "Cannot start SSL connection: " . IO::Socket::SSL::errstr());
     _set_sockopts($sock); # just in case (20101118 kazuho)
     $sock;
 }

--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -693,8 +693,13 @@ sub connect_ssl_over_proxy {
     unless (exists $ssl_opts->{SSL_verifycn_name}) {
         $ssl_opts->{SSL_verifycn_name} = $host;
     }
-    IO::Socket::SSL->start_SSL( $sock, Timeout => $timeout, %$ssl_opts )
-      or return (
+    IO::Socket::SSL->start_SSL(
+        $sock,
+        PeerHost => $host,
+        PeerPort => $port,
+        Timeout  => $timeout,
+        %$ssl_opts
+    ) or return (
           undef, "Cannot start SSL connection: " . _strerror_or_timeout());
     _set_sockopts($sock); # just in case (20101118 kazuho)
     $sock;


### PR DESCRIPTION
Pass `PeerHost` to `IO::Socket::SSL->start_SSL` in `connect_ssl_over_proxy` or otherwise SNI support will be disabled.  This patch makes `connect_ssl_over_proxy` do the same as `connect_ssl` (including a fix for wrong error report).