### PR TITLE
Add `env_proxy' to a couple of files.

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -42,6 +42,7 @@ sub online () {
     }
 
     my $furl = Furl::HTTP->new(timeout => 5);
+    $furl->env_proxy();
     my $good = 0;
     my $bad  = 0;
     note 'checking if online';

--- a/xt/200_online/07_ssl_shutdown.t
+++ b/xt/200_online/07_ssl_shutdown.t
@@ -4,12 +4,18 @@ use warnings;
 use Test::More;
 use Furl;
 use IO::Socket::SSL;
+use t::Util;
 
-my $res = Furl->new(
+skip_if_offline();
+
+my $furl = Furl->new(
     ssl_opts => {
         SSL_verify_mode => SSL_VERIFY_PEER(),
     },
-)->get('https://foursquare.com/login');
+);
+$furl->env_proxy();
+
+my $res = $furl->get('https://foursquare.com/login');
 ok $res->is_success, 'SSL get';
 done_testing;
 


### PR DESCRIPTION
When running the test suite behind a proxy, one test fails
to connect and some other tests are skipped because the
t::Util::online fails to determine if we're actually online.

Added the `env_proxy' before a request is made. The
modified modules are:
1. t\Util.pm
2. xt\200_online\07_ssl_shutdown.t