### PR TITLE
Fix DELETE method not doing accept message body

### DIFF
--- a/lib/Furl.pm
+++ b/lib/Furl.pm
@@ -56,11 +56,12 @@ sub put {
 }
 
 sub delete {
-    my ( $self, $url, $headers ) = @_;
+    my ( $self, $url, $headers, $content ) = @_;
     $self->request(
         method  => 'DELETE',
         url     => $url,
-        headers => $headers
+        headers => $headers,
+        content => $content
     );
 }
 

--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -113,11 +113,12 @@ sub put {
 }
 
 sub delete {
-    my ( $self, $url, $headers ) = @_;
+    my ( $self, $url, $headers, $content ) = @_;
     $self->request(
         method  => 'DELETE',
         url     => $url,
-        headers => $headers
+        headers => $headers,
+        content => $content
     );
 }
 

--- a/t/300_high/01_simple.t
+++ b/t/300_high/01_simple.t
@@ -43,6 +43,7 @@ my @data = (
 
     ['delete', [], sub {  }],
     ['delete', [['X-Foo' => 'bar']], sub { is $_->header('X-Foo'), 'bar'; }],
+    ['delete', [undef, 'doya'], sub { is $_->content_length, 4; is $_->content, 'doya'; }],
 );
 
 test_tcp(


### PR DESCRIPTION
I want to use message body by delete method
example of use: Elasticsearch Delete by query API https://www.elastic.co/guide/en/elasticsearch/reference/1.4/docs-delete-by-query.html

RFCを読むとDELETE method request時にmessage body(payload) 送ると拒絶する実装がある、という例が書いてありますが、送信すること自体は問題なさそうです。

Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing
3.3. Message Body
>   The presence of a message body in a request is signaled by a
>   Content-Length or Transfer-Encoding header field.  Request message
>   framing is independent of method semantics, even if the method does
>   not define any use for a message body.
http://tools.ietf.org/rfc/rfc7230.txt

Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content
4.3.5.  DELETE
>   A payload within a DELETE request message has no defined semantics;
>   sending a payload body on a DELETE request might cause some existing
>   implementations to reject the request.
http://tools.ietf.org/html/rfc7231
