### PR TITLE
Support `100 Continue` response

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -482,6 +482,10 @@ sub request {
             }
             else {
                 # succeeded
+                if ($res_status == 100) { # Continue
+                    $buf = '';
+                    next LOOP;
+                }
                 $rest_header = substr( $buf, $ret );
                 last LOOP;
             }

--- a/t/100_low/26_headers_only.t
+++ b/t/100_low/26_headers_only.t
@@ -14,7 +14,7 @@ test_tcp(
             bufsize => 10,
             timeout => 3,
         );
-        for my $req_code (qw(100 199 204 304)) {
+        for my $req_code (qw(199 204 304)) {
             for (1 .. $n) {
                 my (undef, $code, $msg, $headers, $content) = $furl->request(
                     port       => $port,

--- a/t/100_low/38_continue.t
+++ b/t/100_low/38_continue.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use utf8;
+use Furl::HTTP;
+use Test::TCP;
+use Test::More;
+use t::HTTPServer;
+
+test_tcp(
+    client => sub {
+        my $port = shift;
+        my $furl = Furl::HTTP->new(bufsize => 10, timeout => 3);
+        my ( undef, $code, $msg, $headers, $content ) =
+            $furl->request(
+                port       => $port,
+                path_query => '/foo',
+                host       => '127.0.0.1',
+                headers    => []
+            );
+        is $code, 200;
+        is $msg, 'OK';
+        is $content, 'OK';
+        done_testing;
+    },
+    server => sub {
+        my $port = shift;
+        my $server = t::HTTPServer->new(port => $port);
+        $server->add_trigger(BEFORE_CALL_APP => sub {
+            my ($self, $csock, $env) = @_;
+            $self->write_all($csock, "HTTP/1.1 100 Continue\015\012\015\012");
+        });
+        $server->run(sub {
+            my $env = shift;
+            return [ 200, [], ['OK'] ];
+        });
+    }
+);

--- a/t/HTTPServer.pm
+++ b/t/HTTPServer.pm
@@ -151,7 +151,9 @@ sub handle_connection {
                 last PARSE_HTTP_REQUEST;
             }
         }
+        $self->call_trigger( "BEFORE_CALL_APP", $csock );
         my $res = $app->( \%env );
+        $self->call_trigger( "AFTER_CALL_APP", $csock );
         my $res_header =
           $self->make_header( $res->[0], $res->[1] ) . "\015\012";
         $self->write_all( $csock, $res_header );


### PR DESCRIPTION
I use [Net::Hadoop::WebHDFS](https://github.com/tagomoris/Net-Hadoop-WebHDFS) that uses Furl to access Hadoop WebHDFS REST API but it sends the response code 100 Continue when the client uses PUT method to create a file.

From https://tools.ietf.org/html/rfc7231#section-6.2

>    A client MUST be able to parse one or more 1xx responses received
   prior to a final response, even if the client does not expect one.  A
   user agent MAY ignore unexpected 1xx responses.

Note that the request header "Expect: 100-continue" is still unsupported even if this patch is applied.
