### PR TITLE
Uri unescape for auth

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -278,9 +278,13 @@ sub request {
                 = $self->_parse_url($proxy);
             my $proxy_authorization;
             if (defined $proxy_user) {
+                _requires('URI/Escape.pm',
+                    'Basic auth');
+                my($unescape_proxy_user) = URI::Escape::uri_unescape($proxy_user);
+                my($unescape_proxy_pass) = URI::Escape::uri_unescape($proxy_pass);
                 _requires('MIME/Base64.pm',
                     'Basic auth');
-                $proxy_authorization = 'Basic ' . MIME::Base64::encode_base64("$proxy_user:$proxy_pass","");
+                $proxy_authorization = 'Basic ' . MIME::Base64::encode_base64("$unescape_proxy_user:$unescape_proxy_pass","");
             }
             if ($scheme eq 'http') {
                 ($sock, $err_reason)
@@ -331,8 +335,11 @@ sub request {
             push @headers, 'Proxy-Authorization', $self->{proxy_authorization};
         }
         if (defined $username) {
+            _requires('URI/Escape.pm', 'Basic auth');
+            my($unescape_username) = URI::Escape::uri_unescape($username);
+            my($unescape_password) = URI::Escape::uri_unescape($password);
             _requires('MIME/Base64.pm', 'Basic auth');
-            push @headers, 'Authorization', 'Basic ' . MIME::Base64::encode_base64("${username}:${password}","");
+            push @headers, 'Authorization', 'Basic ' . MIME::Base64::encode_base64("${unescape_username}:${unescape_password}","");
         }
 
         # set Cookie header

--- a/t/100_low/32_proxy_auth.t
+++ b/t/100_low/32_proxy_auth.t
@@ -9,7 +9,7 @@ use Plack::Request;
 use Test::Requires qw(Plack::Request HTTP::Proxy::HeaderFilter::simple HTTP::Body), 'HTTP::Proxy';
 use MIME::Base64 qw/encode_base64/;
 
-plan tests => 7*3;
+plan tests => 7*6;
 
 my $verbose = 1;
 {
@@ -44,6 +44,20 @@ test_tcp(
                     is $content, 'Hello, foo'
                         or do{ require Devel::Peek; Devel::Peek::Dump($content) };
                 }
+                for (4..6) { # run some times for testing keep-alive.
+                    my $furl = Furl::HTTP->new(proxy => "http://dan%40kogai:kogai%2Fdan\@127.0.0.1:$proxy_port");
+                    my ( undef, $code, $msg, $headers, $content ) =
+                        $furl->request(
+                            url     => "http://127.0.0.1:$httpd_port/escape",
+                            headers => [ "X-Foo" => "qqq" ]
+                        );
+                    is $code, 200, "request()";
+                    is $msg, "OK";
+                    is Furl::HTTP::_header_get($headers, 'Content-Length'), 10;
+                    is Furl::HTTP::_header_get($headers, 'Via'), "1.0 $via";
+                    is $content, 'Hello, foo'
+                        or do{ require Devel::Peek; Devel::Peek::Dump($content) };
+                }
             },
             server => sub { # http server
                 my $httpd_port = shift;
@@ -52,6 +66,7 @@ test_tcp(
 
                     my $req = Plack::Request->new($env);
                     is $req->header('X-Foo'), "ppp" if $env->{REQUEST_URI} eq '/foo';
+                    is $req->header('X-Foo'), "qqq" if $env->{REQUEST_URI} eq '/escape';
                     like $req->header('User-Agent'), qr/\A Furl::HTTP /xms;
                     my $content = "Hello, foo";
                     return [ 200,
@@ -65,13 +80,16 @@ test_tcp(
     server => sub { # proxy server
         my $proxy_port = shift;
         my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
-        my $token = "Basic " . encode_base64( "dankogai:kogaidan", "" );
+        my $token_simple = "Basic " . encode_base64( "dankogai:kogaidan", "" );
+        my $token_escape = "Basic " . encode_base64( 'dan@kogai:kogai/dan', "" );
         $proxy->push_filter(
             request => HTTP::Proxy::HeaderFilter::simple->new(
                 sub {
                     my ( $self, $headers, $request ) = @_;
                     my $auth = $self->proxy->hop_headers->header('Proxy-Authorization') || '';
 
+                    my $request_uri = $request->uri->as_string;
+                    my $token = $request_uri =~ m{/escape$} ? $token_escape : $token_simple;
                     # check the credentials
                     if ( $auth ne $token ) {
                         my $response = HTTP::Response->new(407);


### PR DESCRIPTION
Basic認証のusernameとpasswordがURIエスケープされている場合に、
うまく動かないのでその修正になります。
例: http://user%40name@pass%2fword:exapmle.com/

テストは既存のものに追加したんですが、別にしたほうが良かったですかね？
