### PR TITLE
Check whether sockets are readable or not before reusing them

### DIFF
--- a/t/100_low/22_keep_alive.t
+++ b/t/100_low/22_keep_alive.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+
+use Furl::HTTP;
+use Socket ();
+use Test::More;
+use Test::Requires 'Starlet::Server', 'Plack::Loader';
+use Test::TCP;
+
+{
+    no warnings 'redefine';
+    my $orig = *Starlet::Server::_get_acceptor{CODE};
+    *Starlet::Server::_get_acceptor = sub {
+        my $acceptor = shift->$orig(@_);
+        return sub {
+            my ($conn, $peer, $listen) = $acceptor->();
+            if ($conn) {
+                setsockopt($conn, Socket::SOL_SOCKET, Socket::SO_LINGER, pack('ii', 1, 0))
+                    or warn "failed to set SO_LINGER: $!";
+                return ($conn, $peer, $listen);
+            } else {
+                return ();
+            }
+        }
+    };
+}
+
+test_tcp(
+    client => sub {
+        my $port = shift;
+        my $furl = Furl::HTTP->new(timeout => 1);
+        my ($code, $msg);
+        (undef, $code, $msg) = $furl->request(port => $port, host => '127.0.0.1');
+        is $code, 200;
+        is $msg, 'OK';
+        sleep 2;
+        (undef, $code, $msg) = $furl->request(port => $port, host => '127.0.0.1');
+        is $code, 200;
+        is $msg, 'OK';
+    },
+    server => sub {
+        my $port = shift;
+        my %args = (
+            port => $port,
+            keepalive_timeout => 1,
+            max_keepalive_reqs => 100,
+            max_reqs_per_child => 100,
+            max_workers => 1,
+        );
+        my $app = sub { [200, ['Content-Length' => 2], ['ok']] };
+        Plack::Loader->load('Starlet', %args)->run($app);
+        exit;
+    },
+);
+
+done_testing;


### PR DESCRIPTION
This PR addresses #98.

Currently Furl does not check whether sockets are readable or not before reusing them.
If the sockets are readable, then it means they are closed or there are some garbage bytes on them, and either case, we shouldn't reuse them.

While as @kazuho mentioned in #98, there is an inherent race condition that leads to a HTTP request being lost,
I think it is worth to check whether sockets are readable or not before reusing them.

Note:
I confirmed https://github.com/TJC/Furl-bug-demo passed with this PR changes.
```
❯ perl -I /home/skaji/src/github.com/tokuhirom/Furl/lib furlTest.pl
GET #1 successful.
Sleeping 1 sec
GET #2 successful.
Sleeping 3 sec
GET #3 successful.
Sleeping 6 sec
GET #4 successful.
Sleeping 10 sec
GET #5 successful.
Sleeping 15 sec
```

See also:
* HTTP::Tiny https://github.com/chansen/p5-http-tiny/blob/5e6e37afe4cbdf69e59b3593e2c5ded606b6164f/lib/HTTP/Tiny.pm#L1570
* LWP https://github.com/libwww-perl/libwww-perl/blob/dab92a7a46aa50c73205096fe30731f0b9878997/lib/LWP/Protocol/http.pm#L176-L181