### PR TITLE
test requires URI::Escape

### DIFF
--- a/t/100_low/32_proxy_auth.t
+++ b/t/100_low/32_proxy_auth.t
@@ -2,11 +2,10 @@ use strict;
 use warnings;
 use Furl::HTTP;
 use Test::TCP;
-use Test::Requires qw(Plack::Request HTTP::Body), 'Plack', 'MIME::Base64';
+use Test::Requires qw(Plack::Request HTTP::Body MIME::Base64 HTTP::Proxy::HeaderFilter::simple HTTP::Proxy URI::Escape);
 use Plack::Loader;
 use Test::More;
 use Plack::Request;
-use Test::Requires qw(Plack::Request HTTP::Proxy::HeaderFilter::simple HTTP::Body), 'HTTP::Proxy';
 use MIME::Base64 qw/encode_base64/;
 
 plan tests => 7*6;

--- a/t/100_low/33_basic_auth.t
+++ b/t/100_low/33_basic_auth.t
@@ -3,6 +3,7 @@ use warnings;
 use Furl::HTTP;
 use Test::TCP;
 use Test::More;
+use Test::Requires 'URI::Escape';
 use FindBin;
 use lib "$FindBin::Bin/../..";
 use t::HTTPServer;


### PR DESCRIPTION
```
❯ prove -l t/100_low/33_basic_auth.t
t/100_low/33_basic_auth.t .. Basic auth requires URI::Escape, but it is not available. Please install URI::Escape using your prefer CPAN client at t/100_low/33_basic_auth.t line 16.
t/100_low/33_basic_auth.t .. Dubious, test returned 2 (wstat 512, 0x200)
No subtests run

Test Summary Report
-------------------
t/100_low/33_basic_auth.t (Wstat: 512 Tests: 0 Failed: 0)
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
Files=1, Tests=0,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.10 cusr  0.02 csys =  0.15 CPU)
Result: FAIL
```