### PR TITLE
Adjust tests to IPv6-enabled HTTP::Proxy.

### DIFF
--- a/t/100_low/08_proxy.t
+++ b/t/100_low/08_proxy.t
@@ -119,7 +119,7 @@ test_tcp(
     },
     server => sub { # proxy server
         my $proxy_port = shift;
-        my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
+        my $proxy = Test::HTTP::Proxy->new(host => '127.0.0.1', port => $proxy_port, via => $via);
         $proxy->agent(test_agent);
         $proxy->start();
     },
@@ -139,7 +139,7 @@ test_tcp(
     },
     server => sub { # proxy server
         my $proxy_port = shift;
-        my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
+        my $proxy = Test::HTTP::Proxy->new(host => '127.0.0.1', port => $proxy_port, via => $via);
         $proxy->agent(test_agent);
         $proxy->agent->real_httpd_port($httpd->port);
         $proxy->start();
@@ -182,7 +182,7 @@ test_tcp(
     },
     server => sub { # proxy server
         my $proxy_port = shift;
-        my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
+        my $proxy = Test::HTTP::Proxy->new(host => '127.0.0.1', port => $proxy_port, via => $via);
         $proxy->start();
     },
 );

--- a/t/100_low/18_no_proxy.t
+++ b/t/100_low/18_no_proxy.t
@@ -70,7 +70,7 @@ test_tcp(
     },
     server => sub { # proxy server
         my $proxy_port = shift;
-        my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
+        my $proxy = Test::HTTP::Proxy->new(host => '127.0.0.1', port => $proxy_port, via => $via);
         $proxy->start();
     },
 );

--- a/t/100_low/32_proxy_auth.t
+++ b/t/100_low/32_proxy_auth.t
@@ -78,7 +78,7 @@ test_tcp(
     },
     server => sub { # proxy server
         my $proxy_port = shift;
-        my $proxy = Test::HTTP::Proxy->new(port => $proxy_port, via => $via);
+        my $proxy = Test::HTTP::Proxy->new(host => '127.0.0.1', port => $proxy_port, via => $via);
         my $token_simple = "Basic " . encode_base64( "dankogai:kogaidan", "" );
         my $token_escape = "Basic " . encode_base64( 'dan@kogai:kogai/dan', "" );
         $proxy->push_filter(


### PR DESCRIPTION

In Debian we are currently applying the following patch to Furl.
We thought you might be interested in it too.

    Description: Adjust tests to IPv6-enabled HTTP::Proxy.
     The patch from https://rt.cpan.org/Public/Bug/Display.html?id=120275 adds
     IPv6 support to HTTP::Proxy (in Debian added as
     HTTP-Proxy-0.304-Support-IPv6.patch in libhttp-proxy-perl since 0.304-4).
     .
     As HTTP::Proxy listens by default on 'localhost', the three tests
     t/100_low/08_proxy.t, t/100_low/18_no_proxy.t, t/100_low/32_proxy_auth.t
     now fail, as they expect the proxy to run on 127.0.0.1 whereas localhost
     can be ::1 now.
     .
     Change the three tests to run the proxy server explicitly on 127.0.0.1.
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/924859
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2019-03-18
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libfurl-perl/raw/master/debian/patches/1003_proxy_localhost.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
