### PR TITLE
Add support for IPv6 addresses

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl module Furl
 
 {{$NEXT}}
 
+    - Add support for IPv6 URLs like https://[::1]/
+
 3.13 2017-09-19T06:31:34Z
 
     - Fixed test code(skaji++)

--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -182,11 +182,14 @@ sub _parse_url {
             ([^/:@?]+) # password
             @
         )?
-        ([^/:?]+)                   # host
+        (?:
+            \[((?:[\da-fA-F]{0,4})(?::[\da-fA-F]{0,4}){0,7})\]      # IPv6 address
+           |([^/:?]+)               # IPv4 host or hostname
+        )                           # host
         (?: : (\d+) )?              # port
         (?: ( /? \? .* | / .*)  )?  # path_query
     \z}xms or Carp::croak("Passed malformed URL: $url");
-    return( $1, $2, $3, $4, $5, $6 );
+    return( $1, $2, $3, $4 || $5, $6, $7 );
 }
 
 sub make_x_www_form_urlencoded {

--- a/t/999_intrenal/parse_url.t
+++ b/t/999_intrenal/parse_url.t
@@ -176,4 +176,35 @@ test_parse_url(
     'popular IPv6 url',
 );
 
+test_parse_url(
+    'http://[::1]/hoge/fuga?foo=bar',
+    [
+        'http',
+        undef,
+        undef,
+        '::1',
+        undef,
+        '/hoge/fuga?foo=bar',
+    ],
+    'popular IPv6 url with default port',
+);
+
+test_parse_url(
+    'http://[2001:0db8:0000:08d3:0000:8a2e:0070:7344]:5000/hoge/fuga?foo=bar',
+    [
+        'http',
+        undef,
+        undef,
+        '2001:0db8:0000:08d3:0000:8a2e:0070:7344',
+        5000,
+        '/hoge/fuga?foo=bar',
+    ],
+    'Wikipedia IPv6 url with hexadecimal digits',
+);
+
+test_parse_url(
+    'http://[2001a:0db8:0000:08d3:0000:8a2e:0070:7344]:5000/hoge/fuga?foo=bar',
+    qr/Passed malformed URL:/,
+);
+
 done_testing;

--- a/t/999_intrenal/parse_url.t
+++ b/t/999_intrenal/parse_url.t
@@ -163,4 +163,17 @@ test_parse_url(
     qr/Passed malformed URL:/,
 );
 
+test_parse_url(
+    'http://[::1]:5000/hoge/fuga?foo=bar',
+    [
+        'http',
+        undef,
+        undef,
+        '::1',
+        5000,
+        '/hoge/fuga?foo=bar',
+    ],
+    'popular IPv6 url',
+);
+
 done_testing;


### PR DESCRIPTION
As noticed by @jorol in https://github.com/Corion/Test-HTTP-LocalServer/issues/4 , Furl does not handle IPv6 URLs.

This pull request adds tests and support for parsing IPv6 URLs.

It does not add live tests for IPv6 URLs, since not every system binds a socket to IPv6 in a good way for tests.

Thank you for maintaining Furl!