### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
 language: perl
 sudo: false
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ arch:
 language: perl
 sudo: false
 perl:
-  - "5.12"
+  #- "5.12"
   - "5.14"
   - "5.16"
   - "5.18"


### PR DESCRIPTION
Add support for architecture ppc64le.  
Remove perl 5.12 as it is not available.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
