### PR TITLE
Add support for 308

### DIFF
--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -517,7 +517,7 @@ sub request {
     my $do_redirect = undef;
     if ($special_headers->{location}) {
         $max_redirects = defined($args{max_redirects}) ? $args{max_redirects} : $self->{max_redirects};
-        $do_redirect = $max_redirects && $res_status =~ /^30[1237]$/;
+        $do_redirect = $max_redirects && $res_status =~ /^30[12378]$/;
     }
 
     my $res_content = '';
@@ -612,10 +612,11 @@ sub request {
         # response, performing a GET on the Location field-value regardless
         # of the original request method. The status codes 303 and 307 have
         # been added for servers that wish to make unambiguously clear which
-        # kind of reaction is expected of the client.
+        # kind of reaction is expected of the client. Also, 308 was introduced
+        # to avoid the ambiguity of 301.
         return $self->request(
             @_,
-            method        => ($res_status eq '301' or $res_status eq '307') ? $method : 'GET',
+            method        => $res_status =~ /^30[178]$/ ? $method : 'GET',
             url           => $location,
             max_redirects => $max_redirects - 1,
         );

--- a/t/100_low/03_redirect.t
+++ b/t/100_low/03_redirect.t
@@ -66,6 +66,10 @@ test_tcp(
             ( undef, undef, undef, undef, $content ) =
             $furl->post("http://127.0.0.1:$port/307", [], "");
             is $content, 'POST', 'POST into 307 results in a POST';
+
+            ( undef, undef, undef, undef, $content ) =
+            $furl->post("http://127.0.0.1:$port/308", [], "");
+            is $content, 'POST', 'POST into 308 results in a POST';
         };
 
         done_testing;


### PR DESCRIPTION
The status code 308 was introduced by [RFC 7238](https://tools.ietf.org/html/rfc7238) and [RFC 7538](https://tools.ietf.org/html/rfc7538). The status code means `Permanent Redirect`, just like 301, but does not allow changing the method.