### PR TITLE
Unexpected result when specifying Host header

### DIFF
--- a/lib/Furl.pm
+++ b/lib/Furl.pm
@@ -87,7 +87,6 @@ sub request {
         my $req = shift;
         %args = @_;
         my $req_headers= $req->headers;
-        $req_headers->remove_header('Host'); # suppress duplicate Host header
         my $headers = +[
             map {
                 my $k = $_;

--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -403,7 +403,8 @@ sub request {
 
         # finally, set Host header
         my $request_target = ($port == $default_port) ? $host : "$host:$port";
-        push @headers, 'Host' => $request_target;
+        push @headers, 'Host' => $request_target
+            if !defined _header_get(\@headers, 'Host');
 
         my $request_uri = $proxy && $scheme eq 'http' ? "$scheme://$request_target$path_query" : $path_query;
 

--- a/lib/Furl/Response.pm
+++ b/lib/Furl/Response.pm
@@ -32,7 +32,7 @@ sub set_request_info {
 sub captured_req_headers {
     my $self = shift;
     unless (exists $self->{captured_req_headers}) {
-        Carp::croak("You can't call cpatured_req_headers method without 'capture_request' options for Furl#new");
+        Carp::croak("You can't call captured_req_headers method without 'capture_request' options for Furl#new");
     }
     return $self->{captured_req_headers};
 }
@@ -40,7 +40,7 @@ sub captured_req_headers {
 sub captured_req_content {
     my $self = shift;
     unless (exists $self->{captured_req_content}) {
-        Carp::croak("You can't call cpatured_req_content method without 'capture_request' options for Furl#new");
+        Carp::croak("You can't call captured_req_content method without 'capture_request' options for Furl#new");
     }
     return $self->{captured_req_content};
 }

--- a/t/300_high/05_suppress_dup_host_header.t
+++ b/t/300_high/05_suppress_dup_host_header.t
@@ -8,39 +8,55 @@ use FindBin;
 use lib "$FindBin::Bin/../..";
 use t::HTTPServer;
 
-test_tcp(
-    client => sub {
-        my $port = shift;
-        my $furl = Furl->new();
-        my $req = HTTP::Request->new(GET => "http://127.0.0.1:$port/foo");
-        $req->headers->header('Host' => '127.0.0.1');
-        my $res = $furl->request( $req );
-        is $res->code, 200, "HTTP status ok";
-    },
-    server => sub {
-        my $port = shift;
-        my $request;
-        {
-            no warnings 'redefine';
-            my $org = t::HTTPServer->can('parse_http_request');
-            *t::HTTPServer::parse_http_request = sub {
-                $request .= $_[0];
-                $org->(@_); 
-            };
-        }
+my $server_code = sub {
+    my $port = shift;
+    my $request;
+    {
+        no warnings 'redefine';
+        my $org = t::HTTPServer->can('parse_http_request');
+        *t::HTTPServer::parse_http_request = sub {
+            $request .= $_[0];
+            $org->(@_);
+        };
+    }
 
-        t::HTTPServer->new(port => $port)->run(sub {
-            my $env = shift;
-            my $hash;
-            for my $line (split /\n/, $request) {
-                my ($k) = (split ':', $line)[0];
-                $hash->{$k}++;
-            }
-            is $hash->{Host}, 1, 'Host header is one';
-            is $env->{HTTP_HOST}, "127.0.0.1:$port", 'Host header is ok';
-            return [200, ['Content-Length' => 2], ['ok']];
-        });
-    },
-);
+    t::HTTPServer->new(port => $port)->run(sub {
+        my $env = shift;
+        my $hash;
+        for my $line (split /\n/, $request) {
+            my ($k) = (split ':', $line)[0];
+            $hash->{$k}++;
+        }
+        is $hash->{Host}, 1, 'Host header is one';
+        is $env->{HTTP_HOST}, "bar", 'Host header is ok';
+        return [200, ['Content-Length' => 2], ['ok']];
+    });
+};
+
+subtest 'Furl::request' => sub {
+    test_tcp(
+        client => sub {
+            my $port = shift;
+            my $furl = Furl->new();
+            my $req = HTTP::Request->new(GET => "http://127.0.0.1:$port/foo");
+            $req->headers->header('Host' => 'bar');
+            my $res = $furl->request( $req );
+            is $res->code, 200, "HTTP status ok";
+        },
+        server => $server_code,
+    );
+};
+
+subtest 'Furl::get' => sub {
+    test_tcp(
+        client => sub {
+            my $port = shift;
+            my $furl = Furl->new();
+            my $res = $furl->get("http://127.0.0.1:$port/foo", [ Host => 'bar' ]);
+            is $res->code, 200, "HTTP status ok";
+        },
+        server => $server_code,
+    );
+};
 
 done_testing;


### PR DESCRIPTION
Hello, I encountered a problem when I was trying to send request specifying `Host` header.
The `Host` header was not specified as expected.

```
$ perl -E 'use Furl; my $url = "http://www.google.co.jp/"; my $furl = Furl->new(capture_request => 1); my $res = $furl->get($url, [Host => "foo.bar"]); print $res->captured_req_headers;'
GET / HTTP/1.1
Connection: keep-alive
User-Agent: Furl::HTTP/3.14
Host: foo.bar
Host: www.google.co.jp
```

The `Host` header from URL was also added, making 2 `Host` headers in the request, causing `400 Bad Request` on nginx's side.

> Changes with nginx 1.17.9                                        03 Mar 2020
>
>     *) Change: now nginx does not allow several "Host" request header lines.

ref: http://nginx.org/en/CHANGES

It's the same problem as #63. It's said to have been resolved in another PR but seems not yet.
> https://github.com/tokuhirom/Furl/pull/63#issuecomment-28369360

There are 2 cases of this problem:

### Case 1: Calling `Furl::request` with `Host` header specified

User specified `Host` header is removed, while `Host` from URL exists.

```
$ perl -E 'use Furl; use HTTP::Request; my $furl = Furl->new(capture_request => 1); my $req = HTTP::Request->new(GET, "http://www.google.co.jp/"); $req->headers->header(Host => "foo.bar"); my $res = $furl->request($req); print $res->captured_req_headers;'
GET / HTTP/1.1
Connection: keep-alive
User-Agent: Furl::HTTP/3.14
Content-Length: 0
Host: www.google.co.jp
```

### Case 2: Calling `Furl::get` with `Host` header specified

Both user specified `Host` header and `Host` from URL exist (as described at the beginning of this PR).

----

This PR is to fix this header problem. New test case was added too.
I also fixed a typo in croak message, found while reading related code.
https://github.com/tokuhirom/Furl/blob/d518f1f57f2661d766c2c85ccf81566e0937b937/lib/Furl/Response.pm#L35

TOBE:
```
$ perl -E 'use Furl; use HTTP::Request; my $furl = Furl->new(capture_request => 1); my $req = HTTP::Request->new(GET, "http://www.google.co.jp/"); $req->headers->header(Host => "foo.bar"); my $res = $furl->request($req); print $res->captured_req_headers;'
GET / HTTP/1.1
Connection: keep-alive
User-Agent: Furl::HTTP/3.14
Host: foo.bar
Content-Length: 0

$ perl -E 'use Furl; my $url = "http://www.google.co.jp/"; my $furl = Furl->new(capture_request => 1); my $res = $furl->get($url, [Host => "foo.bar"]); print $res->captured_req_headers;'
GET / HTTP/1.1
Connection: keep-alive
User-Agent: Furl::HTTP/3.14
Host: foo.bar
```

Hopefully you would check it and merge this PR if it's OK (or #63, but not sure if still mergable). Regards.