### PR TITLE
Update minimum testing perl version

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.10'
-          - '5.30'
-          - '5.32'
+          - '5.14'
           - '5.34'
+          - '5.36'
+          - '5.38'
     container:
       image: perl:${{ matrix.perl-version }}
     steps:


### PR DESCRIPTION
Some dependencies requires 5.14 or higher versions