### PR TITLE
Fix: return an error on body read timeout when the response has no Content-Length

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.26'
+          - '5.14-buster'
           - '5.34'
           - '5.36'
           - '5.38'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          - '5.14'
+          - '5.26'
           - '5.34'
           - '5.36'
           - '5.38'

--- a/lib/Furl/HTTP.pm
+++ b/lib/Furl/HTTP.pm
@@ -835,13 +835,11 @@ sub _read_body_normal {
     while (!defined($res_content_length) || $res_content_length != $nread) {
         my $n = $self->read_timeout( $sock,
             \my $buf, $self->{bufsize}, 0, $timeout_at );
-        if (!$n) {
+        if (!defined($n)) {
+            return $self->_r500("Cannot read content body: " . _strerror_or_timeout());
+        } elsif (!$n) {
             last if ! defined($res_content_length);
-            return $self->_r500(
-                !defined($n)
-                    ? "Cannot read content body: " . _strerror_or_timeout()
-                    : "Unexpected EOF while reading content body"
-            );
+            return $self->_r500("Unexpected EOF while reading content body");
         }
         $$res_content .= $buf;
         $nread        += $n;

--- a/t/100_low/40_timeout_body_no_content_length.t
+++ b/t/100_low/40_timeout_body_no_content_length.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+
+use Furl::HTTP;
+use IO::Socket::INET;
+use Test::More;
+use Test::TCP;
+
+test_tcp(
+    client => sub {
+        my $port = shift;
+        my $furl = Furl::HTTP->new(timeout => 1);
+        my (undef, $code, $msg) = $furl->request(
+            method  => 'GET',
+            host    => '127.0.0.1',
+            port    => $port,
+            path    => '/',
+        );
+        is $code, 500, "Should return 500 error on timeout while receiving";
+        like $msg,
+             qr/Internal Response: Cannot read content body: timeout/,
+             "Should mention body read timeout";
+    },
+    server => sub {
+        my $port = shift;
+        my $listen_sock = IO::Socket::INET->new(
+            Listen    => 5,
+            LocalHost => '127.0.0.1',
+            LocalPort => $port,
+            ReuseAddr => 1,
+        ) or die $!;
+        local $SIG{PIPE} = 'IGNORE';
+        my $is_skipped_test = 0;
+        while (1) {
+            my $sock = $listen_sock->accept or next;
+
+            # Skip the first readiness probe connection from Test::TCP
+            if (! $is_skipped_test) {
+                close $sock;
+                $is_skipped_test = 1;
+                next;
+            }
+
+            sysread($sock, my $buf, 1048576, 0); # read request
+
+            # send headers (no Content-Length)
+            syswrite $sock, join(
+                "\r\n",
+                "HTTP/1.0 200 OK",
+                "Content-Type: text/plain",
+                "",
+                "abcde",
+            );
+            sleep 3;
+            close $sock;
+        }
+    },
+);
+
+done_testing;


### PR DESCRIPTION
(日本語で失礼します。英語で作成したほうが良ければご連絡ください)

## 概要

通常、HTTP レスポンスボディの受信中にクライアント側でタイムアウトした場合は、
`Cannot read content body: timeout ...` というエラーを返す挙動になっています。
https://github.com/tokuhirom/Furl/blob/9866ebf2ad86593c62e2fd965c493474fcdc3f8a/lib/Furl/HTTP.pm#L842

しかし、レスポンスヘッダに `Content-Length` がない場合に限って、
タイムアウト時でもその時点まで受信できたボディを正常扱いで返してしまう挙動がありました
（結果としてボディが途中で切れてしまう）。
https://github.com/tokuhirom/Furl/blob/9866ebf2ad86593c62e2fd965c493474fcdc3f8a/lib/Furl/HTTP.pm#L839

この挙動を修正し、`Content-Length` がない場合でもボディ受信中のタイムアウトはエラーを返すようにしました。

## 経緯

あるスクリプトで JSON を返す API に対して以下のようなリクエストを実行していましたが、
まれに JSON のデコードに失敗しました（`$res->is_success` を確認後にもかかわらず）。

```perl
my $furl = Furl->new(timeout => 60);
my $res = $furl->get($url);
unless ($res->is_success) {
    die "Failed to get";
}
my $data = JSON::XS::decode_json $res->content;
```

失敗時はスクリプトの実行時間がタイムアウト値と同程度になっていることが多く（通常は 2〜3秒）、
タイムアウトを 60 秒から 1 秒へ下げると高確率で再現しました。

このことから、「クライアント側でのタイムアウトが発生したときに `$res->is_success` になるが、レスポンスが途中で切れてしまう」というパターンがあることに気付きました。

一次対応として JSON デコード失敗時にリトライしていますが、本修正により根本的に解消されます。
方針・実装内容のご確認をお願いいたします。